### PR TITLE
feat(callback): enhance verifySignature function to support custom verifier

### DIFF
--- a/.changeset/silent-hounds-grin.md
+++ b/.changeset/silent-hounds-grin.md
@@ -1,0 +1,5 @@
+---
+"@agentstudio/sdk": patch
+---
+
+Support custom verifier in verifySignature utility


### PR DESCRIPTION
- Added an optional `verifier` parameter to the `verifySignature` function, allowing for custom signature verification logic.
- Updated the implementation to use the custom verifier if provided, falling back to the default verification method otherwise.